### PR TITLE
feat: show column pairing on main screen

### DIFF
--- a/excel_diff_app.pyw
+++ b/excel_diff_app.pyw
@@ -19,6 +19,10 @@ class ExcelDiffApp:
         self.column_options2 = []
         self.column_pairs = []
 
+        self.list1 = None
+        self.list2 = None
+        self.pair_list = None
+
         self._build_ui()
 
     def _build_ui(self):
@@ -34,26 +38,31 @@ class ExcelDiffApp:
         ttk.Entry(frame, textvariable=self.file2_path, width=60).grid(row=1, column=1)
         ttk.Button(frame, text="Обзор", command=self.load_file2).grid(row=1, column=2)
 
-        # Column mapping widgets
-        ttk.Label(frame, text="Столбец проекта (Отчёт 1):").grid(row=2, column=0, sticky="w")
-        self.project_col1 = tk.StringVar()
-        self.project_menu1 = ttk.Combobox(frame, textvariable=self.project_col1, values=self.column_options1, state="readonly", width=57)
-        self.project_menu1.grid(row=2, column=1)
+        # Column pair widgets
+        pair_frame = ttk.Frame(frame)
+        pair_frame.grid(row=2, column=0, columnspan=3, pady=5)
 
-        ttk.Label(frame, text="Столбец проекта (Отчёт 2):").grid(row=3, column=0, sticky="w")
-        self.project_col2 = tk.StringVar()
-        self.project_menu2 = ttk.Combobox(frame, textvariable=self.project_col2, values=self.column_options2, state="readonly", width=57)
-        self.project_menu2.grid(row=3, column=1)
+        ttk.Label(pair_frame, text="Столбцы отчёта 1").grid(row=0, column=0)
+        ttk.Label(pair_frame, text="Столбцы отчёта 2").grid(row=0, column=1)
 
-        ttk.Button(frame, text="Пары столбцов...", command=self.open_pair_window).grid(row=4, column=1, pady=5)
+        self.list1 = tk.Listbox(pair_frame, exportselection=False, height=15, width=30)
+        self.list1.grid(row=1, column=0, padx=5)
+
+        self.list2 = tk.Listbox(pair_frame, exportselection=False, height=15, width=30)
+        self.list2.grid(row=1, column=1, padx=5)
+
+        ttk.Button(pair_frame, text="Добавить пару", command=self.add_pair).grid(row=1, column=2, padx=5)
+
+        self.pair_list = tk.Listbox(pair_frame, height=10, width=60)
+        self.pair_list.grid(row=2, column=0, columnspan=2, pady=5)
 
         # Output file selector
-        ttk.Label(frame, text="Выходной файл:").grid(row=5, column=0, sticky="w")
-        ttk.Entry(frame, textvariable=self.output_path, width=60).grid(row=5, column=1)
-        ttk.Button(frame, text="Сохранить как", command=self.choose_output).grid(row=5, column=2)
+        ttk.Label(frame, text="Выходной файл:").grid(row=3, column=0, sticky="w")
+        ttk.Entry(frame, textvariable=self.output_path, width=60).grid(row=3, column=1)
+        ttk.Button(frame, text="Сохранить как", command=self.choose_output).grid(row=3, column=2)
 
         # Process button
-        ttk.Button(frame, text="Вычислить разницу", command=self.process).grid(row=6, column=1, pady=10)
+        ttk.Button(frame, text="Вычислить разницу", command=self.process).grid(row=4, column=1, pady=10)
 
     def load_file1(self):
         path = filedialog.askopenfilename(filetypes=[("Excel files", "*.xlsx *.xls")])
@@ -65,9 +74,10 @@ class ExcelDiffApp:
             messagebox.showerror("Ошибка", f"Не удалось загрузить файл: {exc}")
             return
         self.file1_path.set(path)
-        self.column_options1 = list(self.df1.columns)
-        self.project_menu1['values'] = self.column_options1
-        self.column_pairs.clear()
+        self.column_options1 = [c for c in self.df1.columns if not str(c).lower().startswith('unnamed')]
+        self.list1.delete(0, tk.END)
+        for col in self.column_options1:
+            self.list1.insert(tk.END, col)
 
     def load_file2(self):
         path = filedialog.askopenfilename(filetypes=[("Excel files", "*.xlsx *.xls")])
@@ -79,9 +89,20 @@ class ExcelDiffApp:
             messagebox.showerror("Ошибка", f"Не удалось загрузить файл: {exc}")
             return
         self.file2_path.set(path)
-        self.column_options2 = list(self.df2.columns)
-        self.project_menu2['values'] = self.column_options2
-        self.column_pairs.clear()
+        self.column_options2 = [c for c in self.df2.columns if not str(c).lower().startswith('unnamed')]
+        self.list2.delete(0, tk.END)
+        for col in self.column_options2:
+            self.list2.insert(tk.END, col)
+
+    def add_pair(self):
+        sel1 = self.list1.curselection()
+        sel2 = self.list2.curselection()
+        if not sel1 or not sel2:
+            return
+        c1 = self.list1.get(sel1[0])
+        c2 = self.list2.get(sel2[0])
+        self.column_pairs.append((c1, c2))
+        self.pair_list.insert(tk.END, f"{c1} <-> {c2}")
 
     def choose_output(self):
         path = filedialog.asksaveasfilename(defaultextension=".xlsx", filetypes=[("Excel files", "*.xlsx")])
@@ -90,23 +111,22 @@ class ExcelDiffApp:
 
     def process(self):
         if not all([self.df1 is not None, self.df2 is not None,
-                    self.project_col1.get(), self.project_col2.get(),
                     self.column_pairs, self.output_path.get()]):
             messagebox.showwarning("Недостаточно данных", "Загрузите отчёты, выберите столбцы и выходной файл.")
             return
 
         try:
+            proj_col1, proj_col2 = self.column_pairs[0]
             merged = self.df1.merge(
                 self.df2,
-                left_on=self.project_col1.get(),
-                right_on=self.project_col2.get(),
+                left_on=proj_col1,
+                right_on=proj_col2,
                 suffixes=("_1", "_2")
             )
-            proj_name = self.project_col1.get()
-            proj_col = proj_name + ("_1" if proj_name in self.df2.columns else "")
+            proj_col = proj_col1 + ("_1" if proj_col1 in self.df2.columns else "")
             result = merged[[proj_col]].copy()
-            result.rename(columns={proj_col: proj_name}, inplace=True)
-            for c1, c2 in self.column_pairs:
+            result.rename(columns={proj_col: proj_col1}, inplace=True)
+            for c1, c2 in self.column_pairs[1:]:
                 c1_name = c1 + ("_1" if c1 in self.df2.columns else "")
                 c2_name = c2 + ("_2" if c2 in self.df1.columns else "")
                 result[f"{c1} - {c2}"] = merged[c1_name] - merged[c2_name]
@@ -128,40 +148,6 @@ class ExcelDiffApp:
         for _, row in df.iterrows():
             tree.insert('', tk.END, values=list(row))
         tree.pack(fill=tk.BOTH, expand=True)
-
-    def open_pair_window(self):
-        if not (self.column_options1 and self.column_options2):
-            messagebox.showwarning("Нет данных", "Сначала загрузите оба отчёта.")
-            return
-
-        win = tk.Toplevel(self.master)
-        win.title("Пары столбцов")
-
-        list1 = tk.Listbox(win, exportselection=False, height=15, width=30)
-        for col in self.column_options1:
-            list1.insert(tk.END, col)
-        list1.grid(row=0, column=0, padx=5, pady=5)
-
-        list2 = tk.Listbox(win, exportselection=False, height=15, width=30)
-        for col in self.column_options2:
-            list2.insert(tk.END, col)
-        list2.grid(row=0, column=1, padx=5, pady=5)
-
-        pair_list = tk.Listbox(win, height=10, width=60)
-        pair_list.grid(row=1, column=0, columnspan=2, padx=5, pady=5)
-
-        def add_pair():
-            sel1 = list1.curselection()
-            sel2 = list2.curselection()
-            if not sel1 or not sel2:
-                return
-            c1 = list1.get(sel1[0])
-            c2 = list2.get(sel2[0])
-            self.column_pairs.append((c1, c2))
-            pair_list.insert(tk.END, f"{c1} <-> {c2}")
-
-        ttk.Button(win, text="Добавить пару", command=add_pair).grid(row=0, column=2, padx=5)
-        ttk.Button(win, text="Закрыть", command=win.destroy).grid(row=1, column=2, padx=5, pady=5, sticky="s")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- move column pair selection to main window and remove report column fields
- ignore "Unnamed" headers when loading reports
- reuse first pair for merge and keep added pairs in list

## Testing
- `python -m py_compile excel_diff_app.pyw`


------
https://chatgpt.com/codex/tasks/task_e_68a7052bec40833390917dfa1b4aae7b